### PR TITLE
Update paging package to be version agnostic

### DIFF
--- a/cache/metadata_test.go
+++ b/cache/metadata_test.go
@@ -130,8 +130,8 @@ func testPagination[T Named, S PagingSlice[T]](t *testing.T, slice S) {
 				current++
 			}
 
-			if result.PageInfo.NextToken != "" {
-				page.Token = result.PageInfo.NextToken
+			if result.NextToken != "" {
+				page.Token = result.NextToken
 			} else {
 				break
 			}

--- a/cache/paging.go
+++ b/cache/paging.go
@@ -10,15 +10,10 @@ type RelationTypeSlice []*dsc2.RelationType
 type PermissionSlice []*dsc2.Permission
 
 func (s ObjectTypeSlice) Paginate(page *dsc2.PaginationRequest) (*paging.Result[*dsc2.ObjectType], error) {
-	if paging.IsCountOnly(page) {
-		return &paging.Result[*dsc2.ObjectType]{
-			PageInfo: &dsc2.PaginationResponse{ResultSize: int32(len(s))},
-		}, nil
-	}
-
 	return paging.PaginateSlice(
 		s,
-		page,
+		page.Size,
+		page.Token,
 		1,
 		func(keys []string, ot *dsc2.ObjectType) bool { return keys[0] == ot.Name },
 		func(ot *dsc2.ObjectType) []string { return []string{ot.Name} },
@@ -26,15 +21,10 @@ func (s ObjectTypeSlice) Paginate(page *dsc2.PaginationRequest) (*paging.Result[
 }
 
 func (s RelationTypeSlice) Paginate(page *dsc2.PaginationRequest) (*paging.Result[*dsc2.RelationType], error) {
-	if paging.IsCountOnly(page) {
-		return &paging.Result[*dsc2.RelationType]{
-			PageInfo: &dsc2.PaginationResponse{ResultSize: int32(len(s))},
-		}, nil
-	}
-
 	return paging.PaginateSlice(
 		s,
-		page,
+		page.Size,
+		page.Token,
 		2,
 		func(keys []string, relType *dsc2.RelationType) bool {
 			return keys[0] == relType.ObjectType && keys[1] == relType.Name
@@ -44,15 +34,10 @@ func (s RelationTypeSlice) Paginate(page *dsc2.PaginationRequest) (*paging.Resul
 }
 
 func (s PermissionSlice) Paginate(page *dsc2.PaginationRequest) (*paging.Result[*dsc2.Permission], error) {
-	if paging.IsCountOnly(page) {
-		return &paging.Result[*dsc2.Permission]{
-			PageInfo: &dsc2.PaginationResponse{ResultSize: int32(len(s))},
-		}, nil
-	}
-
 	return paging.PaginateSlice(
 		s,
-		page,
+		page.Size,
+		page.Token,
 		1,
 		func(keys []string, p *dsc2.Permission) bool { return keys[0] == p.Name },
 		func(p *dsc2.Permission) []string { return []string{p.Name} },

--- a/paging/cursor.go
+++ b/paging/cursor.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"encoding/gob"
 
-	dsc2 "github.com/aserto-dev/go-directory/aserto/directory/common/v2"
 	"github.com/aserto-dev/go-directory/pkg/derr"
 )
 
@@ -71,11 +70,4 @@ func (c *Cursor) Encode() (string, error) {
 	}
 
 	return base64.RawStdEncoding.EncodeToString(buf.Bytes()), nil
-}
-
-func IsCountOnly(p *dsc2.PaginationRequest) bool {
-	if p == nil {
-		return false
-	}
-	return p.Size == TotalsOnlyResultSet
 }


### PR DESCRIPTION
This PR allows that pagination logic to be used with either v2 or v3 services.