### PR TITLE
fix loading empty manifest

### DIFF
--- a/v2/load.go
+++ b/v2/load.go
@@ -14,13 +14,16 @@ func Load(r io.Reader) (*model.Model, error) {
 	dec := yaml.NewDecoder(r)
 	dec.KnownFields(true)
 
-	if err := dec.Decode(&manifest); err != nil {
-		return nil, err
-	}
-
 	m := model.Model{
 		Version: model.ModelVersion,
 		Objects: map[model.ObjectName]*model.Object{},
+	}
+
+	if err := dec.Decode(&manifest); err != nil {
+		if err == io.EOF {
+			return &m, nil
+		}
+		return nil, err
 	}
 
 	for objName, obj := range manifest {

--- a/v2/manifest_test.go
+++ b/v2/manifest_test.go
@@ -1,6 +1,7 @@
 package v2_test
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
 	"testing"
@@ -42,4 +43,16 @@ func TestLoadModel(t *testing.T) {
 	if err := enc.Encode(model); err != nil {
 		require.NoError(t, err)
 	}
+}
+
+func TestLoadEmptyManifest(t *testing.T) {
+	r := bytes.NewReader([]byte{})
+
+	m1, err := v2.Load(r)
+	require.NoError(t, err)
+	require.NotNil(t, m1)
+
+	b1, err := json.Marshal(m1)
+	require.NoError(t, err)
+	require.NotNil(t, b1)
 }

--- a/v3/load.go
+++ b/v3/load.go
@@ -14,13 +14,16 @@ func Load(r io.Reader) (*model.Model, error) {
 	dec := yaml.NewDecoder(r)
 	dec.KnownFields(true)
 
-	if err := dec.Decode(&manifest); err != nil {
-		return nil, err
-	}
-
 	m := model.Model{
 		Version: model.ModelVersion,
 		Objects: map[model.ObjectName]*model.Object{},
+	}
+
+	if err := dec.Decode(&manifest); err != nil {
+		if err == io.EOF {
+			return &m, nil
+		}
+		return nil, err
 	}
 
 	for on, o := range manifest.ObjectTypes {

--- a/v3/manifest_test.go
+++ b/v3/manifest_test.go
@@ -1,6 +1,7 @@
 package v3_test
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
 	"testing"
@@ -51,4 +52,17 @@ func TestLoadModel(t *testing.T) {
 	if diff, str := jsondiff.Compare(b1, b2, &opts); diff != jsondiff.FullMatch {
 		require.Equal(t, jsondiff.FullMatch, diff, "diff: %s", str)
 	}
+}
+
+func TestLoadEmptyManifest(t *testing.T) {
+	r := bytes.NewReader([]byte{})
+
+	m1, err := v3.Load(r)
+	require.NoError(t, err)
+	require.NotNil(t, m1)
+
+	b1, err := json.Marshal(m1)
+	require.NoError(t, err)
+	require.NotNil(t, b1)
+
 }


### PR DESCRIPTION
When `Decode` of the manifest fails with an error == `io.EOF`, return an empty model instance instead of passing on the `io.EOF` error