### PR TITLE
Implement tracing in Check calls

### DIFF
--- a/check/check_test.go
+++ b/check/check_test.go
@@ -2,6 +2,7 @@ package check_test
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	azmcheck "github.com/aserto-dev/azm/check"
@@ -147,6 +148,7 @@ func TestCheck(t *testing.T) {
 
 			res, err := checker.Check()
 			assert.NoError(err)
+			tt.Log("trace:\n", strings.Join(checker.Trace(), "\n"))
 			assert.Equal(test.expected, res)
 		})
 	}
@@ -164,6 +166,7 @@ func check(
 		Relation:    relation.String(),
 		SubjectType: subjectType.String(),
 		SubjectId:   subjectID,
+		Trace: true,
 	}
 
 }

--- a/check/memo.go
+++ b/check/memo.go
@@ -1,0 +1,106 @@
+package check
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/samber/lo"
+)
+
+type checkStatus int
+
+func (s checkStatus) String() string {
+	switch s {
+	case checkStatusUnknown:
+		return "unknown"
+	case checkStatusPending:
+		return "?"
+	case checkStatusTrue:
+		return "true"
+	case checkStatusFalse:
+		return "false"
+	default:
+		return fmt.Sprintf("invalid: %d", s)
+	}
+}
+
+const (
+	checkStatusUnknown checkStatus = iota
+	checkStatusPending
+	checkStatusTrue
+	checkStatusFalse
+)
+
+type checkCall struct {
+	*checkParams
+	status checkStatus
+}
+
+// checkMemo tracks pending checks to detect cycles, and caches the results of completed checks.
+type checkMemo struct {
+	memo    map[checkParams]checkStatus
+	history []*checkCall
+}
+
+func newCheckMemo(trace bool) *checkMemo {
+	return &checkMemo{
+		memo:    map[checkParams]checkStatus{},
+		history: lo.Ternary(trace, []*checkCall{}, nil),
+	}
+}
+
+// MarkVisited returns the status of a check. If the check has not been visited, it is marked as pending.
+func (m *checkMemo) MarkVisited(params *checkParams) checkStatus {
+	prior := m.memo[*params]
+	current := prior
+	if prior == checkStatusUnknown {
+		current = checkStatusPending
+		m.memo[*params] = current
+	}
+
+	m.trace(params, current)
+
+	return prior
+}
+
+// MarkComplete records the result of a check.
+func (m *checkMemo) MarkComplete(params *checkParams, checkResult bool) {
+	status := checkStatusFalse
+	if checkResult {
+		status = checkStatusTrue
+	}
+	m.memo[*params] = status
+
+	m.trace(params, status)
+}
+
+func (m *checkMemo) Trace() []string {
+	if m.history == nil {
+		return []string{}
+	}
+
+	callstack := []string{}
+
+	return lo.Map(m.history, func(c *checkCall, _ int) string {
+		call := c.String()
+		result := c.status.String()
+
+		if len(callstack) > 0 && callstack[len(callstack)-1] == call && c.status != checkStatusPending {
+			callstack = callstack[:len(callstack)-1]
+		}
+
+		s := fmt.Sprintf("%s%s = %s", strings.Repeat("  ", len(callstack)), call, result)
+
+		if c.status == checkStatusPending {
+			callstack = append(callstack, call)
+		}
+
+		return s
+	})
+}
+
+func (m *checkMemo) trace(params *checkParams, status checkStatus) {
+	if m.history != nil {
+		m.history = append(m.history, &checkCall{params, status})
+	}
+}


### PR DESCRIPTION
This adds tracing to the Checker.
Traces remain string slices where each element is of the form `objType:objID#relation@subjType:subjID = status`.
The status can be one of `true`, `false`, or `?`. The latter indicates where check calls were initiated and may have spawned child checks.
The trace strings are intended to reflect the hierarchical structure of the overall request.

For example:
```
doc:doc1#can_invite@user:f1_owner = ?
  folder:folder1#can_read@user:f1_owner = ?
    folder:folder1#viewer@user:f1_owner = ?
      group:f1_viewers#member@user:f1_owner = ?
      group:f1_viewers#member@user:f1_owner = false
    folder:folder1#viewer@user:f1_owner = false
    folder:folder1#owner@user:f1_owner = ?
    folder:folder1#owner@user:f1_owner = true
  folder:folder1#can_read@user:f1_owner = true
  doc:doc1#viewer@user:f1_owner = ?
    group:d1_viewers#member@user:f1_owner = ?
      group:d1_subviewers#member@user:f1_owner = ?
    group:d1_viewers#member@user:f1_owner = ?
      group:d1_subviewers#member@user:f1_owner = ?
      group:d1_subviewers#member@user:f1_owner = false
    group:d1_viewers#member@user:f1_owner = false
  doc:doc1#viewer@user:f1_owner = false
doc:doc1#can_invite@user:f1_owner = true
```
