### PR TITLE
Remove unnecessary RelationTerm struct

### DIFF
--- a/cache/expand.go
+++ b/cache/expand.go
@@ -78,7 +78,7 @@ func (c *Cache) expandUnion(o *model.Object, u ...*model.PermissionTerm) []model
 		}
 
 		result = append(result, ref.RelOrPerm)
-		exp := lo.FilterMap(o.Relations[ref.RelOrPerm].Union, func(r *model.RelationTerm, _ int) (*model.PermissionTerm, bool) {
+		exp := lo.FilterMap(o.Relations[ref.RelOrPerm].Union, func(r *model.RelationRef, _ int) (*model.PermissionTerm, bool) {
 			if !r.IsDirect() {
 				return &model.PermissionTerm{}, false
 			}

--- a/check/check.go
+++ b/check/check.go
@@ -161,14 +161,14 @@ func (c *Checker) checkRelation(params *checkParams) (bool, error) {
 }
 
 func (c *Checker) stepRelation(r *model.Relation, subjs ...model.ObjectName) []*model.RelationRef {
-	steps := lo.FilterMap(r.Union, func(rt *model.RelationTerm, _ int) (*model.RelationRef, bool) {
-		if rt.IsDirect() || rt.IsWildcard() {
+	steps := lo.FilterMap(r.Union, func(rr *model.RelationRef, _ int) (*model.RelationRef, bool) {
+		if rr.IsDirect() || rr.IsWildcard() {
 			// include direct or wildcard with the expected types.
-			return rt.RelationRef, len(subjs) == 0 || lo.Contains(subjs, rt.Object)
+			return rr, len(subjs) == 0 || lo.Contains(subjs, rr.Object)
 		}
 
 		// include subject relations that can resolve to the expected types.
-		return rt.RelationRef, len(subjs) == 0 || len(lo.Intersect(c.m.Objects[rt.Object].Relations[rt.Relation].SubjectTypes, subjs)) > 0
+		return rr, len(subjs) == 0 || len(lo.Intersect(c.m.Objects[rr.Object].Relations[rr.Relation].SubjectTypes, subjs)) > 0
 	})
 
 	sort.Slice(steps, func(i, j int) bool {

--- a/check/check_test.go
+++ b/check/check_test.go
@@ -166,7 +166,7 @@ func check(
 		Relation:    relation.String(),
 		SubjectType: subjectType.String(),
 		SubjectId:   subjectID,
-		Trace: true,
+		Trace:       true,
 	}
 
 }

--- a/model/model.go
+++ b/model/model.go
@@ -257,15 +257,15 @@ func (m *Model) resolveRelation(r *Relation, seen relSet) []ObjectName {
 	}
 
 	subjectTypes := set.NewSet[ObjectName]()
-	for _, rt := range r.Union {
+	for _, rr := range r.Union {
 		switch {
-		case rt.IsSubject():
-			if !seen.Contains(*rt.RelationRef) {
-				seen.Add(*rt.RelationRef)
-				subjectTypes.Append(m.resolveRelation(m.Objects[rt.Object].Relations[rt.Relation], seen)...)
+		case rr.IsSubject():
+			if !seen.Contains(*rr) {
+				seen.Add(*rr)
+				subjectTypes.Append(m.resolveRelation(m.Objects[rr.Object].Relations[rr.Relation], seen)...)
 			}
 		default:
-			subjectTypes.Add(rt.Object)
+			subjectTypes.Add(rr.Object)
 		}
 	}
 	return subjectTypes.ToSlice()

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -21,12 +21,9 @@ var m1 = model.Model{
 		model.ObjectName("group"): {
 			Relations: map[model.RelationName]*model.Relation{
 				model.RelationName("member"): {
-					Union: []*model.RelationTerm{
-						{RelationRef: &model.RelationRef{Object: model.ObjectName("user")}},
-						{RelationRef: &model.RelationRef{
-							Object:   model.ObjectName("group"),
-							Relation: model.RelationName("member"),
-						}},
+					Union: []*model.RelationRef{
+						{Object: model.ObjectName("user")},
+						{Object: model.ObjectName("group"), Relation: model.RelationName("member")},
 					},
 				},
 			},
@@ -35,8 +32,8 @@ var m1 = model.Model{
 		model.ObjectName("folder"): {
 			Relations: map[model.RelationName]*model.Relation{
 				model.RelationName("owner"): {
-					Union: []*model.RelationTerm{
-						{RelationRef: &model.RelationRef{Object: model.ObjectName("user")}},
+					Union: []*model.RelationRef{
+						{Object: model.ObjectName("user")},
 					},
 				},
 			},
@@ -49,15 +46,15 @@ var m1 = model.Model{
 		model.ObjectName("document"): {
 			Relations: map[model.RelationName]*model.Relation{
 				model.RelationName("parent_folder"): {
-					Union: []*model.RelationTerm{{RelationRef: &model.RelationRef{Object: model.ObjectName("folder")}}},
+					Union: []*model.RelationRef{{Object: model.ObjectName("folder")}},
 				},
 				model.RelationName("writer"): {
-					Union: []*model.RelationTerm{{RelationRef: &model.RelationRef{Object: model.ObjectName("user")}}},
+					Union: []*model.RelationRef{{Object: model.ObjectName("user")}},
 				},
 				model.RelationName("reader"): {
-					Union: []*model.RelationTerm{
-						{RelationRef: &model.RelationRef{Object: model.ObjectName("user")}},
-						{RelationRef: &model.RelationRef{Object: model.ObjectName("user"), Relation: "*"}},
+					Union: []*model.RelationRef{
+						{Object: model.ObjectName("user")},
+						{Object: model.ObjectName("user"), Relation: "*"},
 					},
 				},
 			},
@@ -169,14 +166,9 @@ func TestDiff(t *testing.T) {
 			model.ObjectName("group"): {
 				Relations: map[model.RelationName]*model.Relation{
 					model.RelationName("member"): {
-						Union: []*model.RelationTerm{
-							{RelationRef: &model.RelationRef{Object: model.ObjectName("new_user")}},
-							{RelationRef: &model.RelationRef{
-								Object:   model.ObjectName("group"),
-								Relation: model.RelationName("member"),
-							},
-								SubjectTypes: []model.ObjectName{},
-							},
+						Union: []*model.RelationRef{
+							{Object: model.ObjectName("new_user")},
+							{Object: model.ObjectName("group"), Relation: model.RelationName("member")},
 						},
 					},
 				},
@@ -184,10 +176,10 @@ func TestDiff(t *testing.T) {
 			model.ObjectName("folder"): {
 				Relations: map[model.RelationName]*model.Relation{
 					model.RelationName("owner"): {
-						Union: []*model.RelationTerm{{RelationRef: &model.RelationRef{Object: model.ObjectName("new_user")}}},
+						Union: []*model.RelationRef{{Object: model.ObjectName("new_user")}},
 					},
 					model.RelationName("viewer"): {
-						Union: []*model.RelationTerm{{RelationRef: &model.RelationRef{Object: model.ObjectName("new_user")}}},
+						Union: []*model.RelationRef{{Object: model.ObjectName("new_user")}},
 					},
 				},
 				Permissions: map[model.RelationName]*model.Permission{
@@ -199,12 +191,12 @@ func TestDiff(t *testing.T) {
 			model.ObjectName("document"): {
 				Relations: map[model.RelationName]*model.Relation{
 					model.RelationName("writer"): {
-						Union: []*model.RelationTerm{{RelationRef: &model.RelationRef{Object: model.ObjectName("new_user")}}},
+						Union: []*model.RelationRef{{Object: model.ObjectName("new_user")}},
 					},
 					model.RelationName("reader"): {
-						Union: []*model.RelationTerm{
-							{RelationRef: &model.RelationRef{Object: model.ObjectName("new_user")}},
-							{RelationRef: &model.RelationRef{Object: model.ObjectName("new_user"), Relation: "*"}},
+						Union: []*model.RelationRef{
+							{Object: model.ObjectName("new_user")},
+							{Object: model.ObjectName("new_user"), Relation: "*"},
 						},
 					},
 				},
@@ -256,7 +248,7 @@ func TestGraph(t *testing.T) {
 			model.ObjectName("user"): {
 				Relations: map[model.RelationName]*model.Relation{
 					model.RelationName("rel_name"): {
-						Union: []*model.RelationTerm{{RelationRef: &model.RelationRef{Object: model.ObjectName("ext_obj")}}},
+						Union: []*model.RelationRef{{Object: model.ObjectName("ext_obj")}},
 					},
 				},
 			},
@@ -264,12 +256,9 @@ func TestGraph(t *testing.T) {
 			model.ObjectName("group"): {
 				Relations: map[model.RelationName]*model.Relation{
 					model.RelationName("member"): {
-						Union: []*model.RelationTerm{
-							{RelationRef: &model.RelationRef{Object: model.ObjectName("user")}},
-							{RelationRef: &model.RelationRef{
-								Object:   model.ObjectName("group"),
-								Relation: model.RelationName("member"),
-							}},
+						Union: []*model.RelationRef{
+							{Object: model.ObjectName("user")},
+							{Object: model.ObjectName("group"), Relation: model.RelationName("member")},
 						},
 					},
 				},
@@ -277,22 +266,22 @@ func TestGraph(t *testing.T) {
 			model.ObjectName("folder"): {
 				Relations: map[model.RelationName]*model.Relation{
 					model.RelationName("owner"): {
-						Union: []*model.RelationTerm{{RelationRef: &model.RelationRef{Object: model.ObjectName("user")}}},
+						Union: []*model.RelationRef{{Object: model.ObjectName("user")}},
 					},
 				},
 			},
 			model.ObjectName("document"): {
 				Relations: map[model.RelationName]*model.Relation{
 					model.RelationName("parent_folder"): {
-						Union: []*model.RelationTerm{{RelationRef: &model.RelationRef{Object: model.ObjectName("folder")}}},
+						Union: []*model.RelationRef{{Object: model.ObjectName("folder")}},
 					},
 					model.RelationName("writer"): {
-						Union: []*model.RelationTerm{{RelationRef: &model.RelationRef{Object: model.ObjectName("user")}}},
+						Union: []*model.RelationRef{{Object: model.ObjectName("user")}},
 					},
 					model.RelationName("reader"): {
-						Union: []*model.RelationTerm{
-							{RelationRef: &model.RelationRef{Object: model.ObjectName("user")}},
-							{RelationRef: &model.RelationRef{Object: model.ObjectName("user"), Relation: "*"}},
+						Union: []*model.RelationRef{
+							{Object: model.ObjectName("user")},
+							{Object: model.ObjectName("user"), Relation: "*"},
 						},
 					},
 				},

--- a/model/types.go
+++ b/model/types.go
@@ -38,13 +38,8 @@ func (o *Object) HasRelOrPerm(name RelationName) bool {
 }
 
 type Relation struct {
-	Union        []*RelationTerm `json:"union,omitempty"`
-	SubjectTypes []ObjectName    `json:"subject_types,omitempty"`
-}
-
-type RelationTerm struct {
-	*RelationRef
-	SubjectTypes []ObjectName `json:"subject_types,omitempty"`
+	Union        []*RelationRef `json:"union,omitempty"`
+	SubjectTypes []ObjectName   `json:"subject_types,omitempty"`
 }
 
 type RelationRef struct {

--- a/parser/parse.go
+++ b/parser/parse.go
@@ -5,12 +5,12 @@ import (
 	"github.com/aserto-dev/azm/model"
 )
 
-func ParseRelation(input string) []*model.RelationTerm {
+func ParseRelation(input string) []*model.RelationRef {
 	p := newParser(input)
 	rTree := p.Relation()
 
 	var v RelationVisitor
-	return v.Visit(rTree).([]*model.RelationTerm)
+	return v.Visit(rTree).([]*model.RelationRef)
 }
 
 func ParsePermission(input string) *model.Permission {

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -29,7 +29,7 @@ func TestPermissionParser(t *testing.T) {
 
 type relationTest struct {
 	input    string
-	validate func([]*model.RelationTerm, *assert.Assertions)
+	validate func([]*model.RelationRef, *assert.Assertions)
 }
 
 type permissionTest struct {
@@ -40,7 +40,7 @@ type permissionTest struct {
 var relationTests = []relationTest{
 	{
 		"user",
-		func(rel []*model.RelationTerm, assert *assert.Assertions) {
+		func(rel []*model.RelationRef, assert *assert.Assertions) {
 			assert.Len(rel, 1)
 			term := rel[0]
 			assert.True(term.IsDirect())
@@ -50,7 +50,7 @@ var relationTests = []relationTest{
 	},
 	{
 		"name-with-dashes",
-		func(rel []*model.RelationTerm, assert *assert.Assertions) {
+		func(rel []*model.RelationRef, assert *assert.Assertions) {
 			assert.Len(rel, 1)
 			term := rel[0]
 			assert.True(term.IsDirect())
@@ -60,7 +60,7 @@ var relationTests = []relationTest{
 	},
 	{
 		"group#member",
-		func(rel []*model.RelationTerm, assert *assert.Assertions) {
+		func(rel []*model.RelationRef, assert *assert.Assertions) {
 			assert.Len(rel, 1)
 			term := rel[0]
 			assert.True(term.IsSubject())
@@ -70,7 +70,7 @@ var relationTests = []relationTest{
 	},
 	{
 		"user:*",
-		func(rel []*model.RelationTerm, assert *assert.Assertions) {
+		func(rel []*model.RelationRef, assert *assert.Assertions) {
 			assert.Len(rel, 1)
 			term := rel[0]
 			assert.True(term.IsWildcard())
@@ -80,7 +80,7 @@ var relationTests = []relationTest{
 	},
 	{
 		"user | group",
-		func(rel []*model.RelationTerm, assert *assert.Assertions) {
+		func(rel []*model.RelationRef, assert *assert.Assertions) {
 			assert.Len(rel, 2)
 
 			assert.True(rel[0].IsDirect())
@@ -94,7 +94,7 @@ var relationTests = []relationTest{
 	},
 	{
 		"user | group | user:* | group#member",
-		func(rel []*model.RelationTerm, assert *assert.Assertions) {
+		func(rel []*model.RelationRef, assert *assert.Assertions) {
 			assert.Len(rel, 4)
 
 			assert.True(rel[0].IsDirect())

--- a/parser/relation_visitor.go
+++ b/parser/relation_visitor.go
@@ -20,32 +20,29 @@ func (v *RelationVisitor) Visit(tree antlr.ParseTree) interface{} {
 }
 
 func (v *RelationVisitor) VisitRelation(c *RelationContext) interface{} {
-	return lo.Map(c.AllRel(), func(rel IRelContext, _ int) *model.RelationTerm {
-		if term, ok := rel.Accept(v).(*model.RelationTerm); ok {
+	return lo.Map(c.AllRel(), func(rel IRelContext, _ int) *model.RelationRef {
+		if term, ok := rel.Accept(v).(*model.RelationRef); ok {
 			return term
 		}
 
-		return &model.RelationTerm{}
+		return &model.RelationRef{}
 	})
 }
 
 func (v *RelationVisitor) VisitDirectRel(c *DirectRelContext) interface{} {
-	return &model.RelationTerm{RelationRef: &model.RelationRef{Object: model.ObjectName(c.Direct().ID().GetText())}}
+	return &model.RelationRef{Object: model.ObjectName(c.Direct().ID().GetText())}
 }
 
 func (v *RelationVisitor) VisitWildcardRel(c *WildcardRelContext) interface{} {
-	return &model.RelationTerm{RelationRef: &model.RelationRef{
+	return &model.RelationRef{
 		Object:   model.ObjectName(c.Wildcard().ID().GetText()),
 		Relation: "*",
-	}}
+	}
 }
 
 func (v *RelationVisitor) VisitSubjectRel(c *SubjectRelContext) interface{} {
-	return &model.RelationTerm{
-		RelationRef: &model.RelationRef{
-			Object:   model.ObjectName(c.Subject().ID(0).GetText()),
-			Relation: model.RelationName(c.Subject().ID(1).GetText()),
-		},
-		SubjectTypes: []model.ObjectName{},
+	return &model.RelationRef{
+		Object:   model.ObjectName(c.Subject().ID(0).GetText()),
+		Relation: model.RelationName(c.Subject().ID(1).GetText()),
 	}
 }

--- a/v2/load.go
+++ b/v2/load.go
@@ -43,7 +43,7 @@ func Load(r io.Reader) (*model.Model, error) {
 		// create all relation instances
 		for relName := range obj {
 			if _, ok := o.Relations[model.RelationName(relName)]; !ok {
-				o.Relations[model.RelationName(relName)] = &model.Relation{Union: []*model.RelationTerm{}}
+				o.Relations[model.RelationName(relName)] = &model.Relation{Union: []*model.RelationRef{}}
 			}
 		}
 
@@ -55,12 +55,9 @@ func Load(r io.Reader) (*model.Model, error) {
 					return nil, azm.ErrRelationNotFound.Msg(v)
 				}
 
-				rs.Union = append(rs.Union, &model.RelationTerm{
-					RelationRef: &model.RelationRef{
-						Object:   on,
-						Relation: model.RelationName(relName),
-					},
-					SubjectTypes: []model.ObjectName{},
+				rs.Union = append(rs.Union, &model.RelationRef{
+					Object:   on,
+					Relation: model.RelationName(relName),
 				})
 
 				o.Relations[model.RelationName(v)] = rs

--- a/v3/load.go
+++ b/v3/load.go
@@ -31,13 +31,13 @@ func Load(r io.Reader) (*model.Model, error) {
 	for on, o := range manifest.ObjectTypes {
 		log.Debug().Str("object", string(on)).Msg("loading object")
 
-		relationTerms := lo.MapEntries(o.Relations, func(rn RelationName, rd string) (model.RelationName, []*model.RelationTerm) {
+		relationTerms := lo.MapEntries(o.Relations, func(rn RelationName, rd string) (model.RelationName, []*model.RelationRef) {
 			log.Debug().Str("object", string(on)).Str("relation", string(rn)).Msg("loading relation")
 
 			return model.RelationName(rn), parser.ParseRelation(rd)
 		})
 
-		relations := lo.MapEntries(relationTerms, func(rn model.RelationName, rts []*model.RelationTerm) (model.RelationName, *model.Relation) {
+		relations := lo.MapEntries(relationTerms, func(rn model.RelationName, rts []*model.RelationRef) (model.RelationName, *model.Relation) {
 			return rn, &model.Relation{Union: rts}
 		})
 


### PR DESCRIPTION
At some point during the revisions to the mode I introduced a `RelationTerm` struct that wraps a `RelationRef` and adds a list of possible subject types, but that's unnecessary because subject types are tracked at the `Relation` level and each element in a relation is either a single type (possibly with a wildcard) or a subject relation, in which case the set of possible subjects is already recorded in the definition of the other relation.

This PR eliminates `RelationTerm`.