### PR TITLE
Fix inversion of exclusion permissions and model validation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/aserto-dev/azm
 
 go 1.22
 
-toolchain go1.22.5
-
 // replace github.com/aserto-dev/go-directory => ../go-directory
 
 require (

--- a/go.work
+++ b/go.work
@@ -1,7 +1,5 @@
 go 1.22
 
-toolchain go1.22.5
-
 use (
 	.
 	./cmd/azmcmd

--- a/graph/check_test.yaml
+++ b/graph/check_test.yaml
@@ -62,6 +62,12 @@ types:
       can_share: can_write & parent->can_share
       can_invite: parent->can_read - viewer
 
+      # viewer can be user or group but owner can only be user
+      negation_type_subset: viewer - owner
+
+      # viewer can be user or group but owner can only be user
+      intersection_type_subset: viewer & owner
+
   cycle:
     relations:
       parent: cycle

--- a/model/inverse.go
+++ b/model/inverse.go
@@ -55,6 +55,22 @@ func (i *inverter) invert() *Model {
 		}
 	}
 
+	for _, o := range i.im.Objects {
+		for _, p := range o.Permissions {
+			if !p.IsExclusion() {
+				continue
+			}
+
+			if p.Exclusion.Exclude == nil {
+				// It is possible for the 'Exclude' term to be empty in in inverted model if the object type
+				// cannot have the relation/permission being excluded.
+				// In this case, the exclusion permission becomes a single-term union.
+				p.Union = PermissionTerms{p.Exclusion.Include}
+				p.Exclusion = nil
+			}
+		}
+	}
+
 	return i.im
 }
 

--- a/model/types.go
+++ b/model/types.go
@@ -227,6 +227,9 @@ type PermissionTerm struct {
 }
 
 func (pr *PermissionTerm) String() string {
+	if pr == nil {
+		return "<nil>"
+	}
 	s := string(pr.RelOrPerm)
 	if pr.Base != "" {
 		s = string(pr.Base) + "->" + s

--- a/model/validate.go
+++ b/model/validate.go
@@ -161,6 +161,12 @@ func (v *validator) validateObjectPerms(on ObjectName, o *Object) error {
 		}
 
 		for _, term := range terms {
+			if term == nil {
+				errs = multierror.Append(errs, derr.ErrInvalidPermission.Msgf(
+					"permission '%s:%s' has an empty term", on, pn),
+				)
+				continue
+			}
 			switch {
 			case term.IsArrow():
 				// this is an arrow operator.


### PR DESCRIPTION
 This includes two bug fixes:
1. Model validation wasn't checking for `nil` permission terms resulting in a panic instead of an error.
2. During the inversion of exclusion permissions it is possible for the inverted relation to only have the 'include' term without the second 'exclude' term on certain types if objects of that type cannot have the excluded permission/relation to the object being inverted. In such cases the exclusion permission on those types becomes a single-term union.

For example, in this model fragment:
```yaml
doc:
  relations:
    owner: user
    viewer: user | group#member
  permissions:
    can_act: viewer - owner
```

Only users can have the `owner` relation to a `doc` but either users or groups can have the `viewer` relation.
In the inverted model we expect to see:
```yaml
user:
    relations:
        doc^owner: doc
        doc^viewer: doc
        group^member: group
    permissions:
        $doc^viewer: doc^viewer | $group^member->$doc^viewer#member
        $group^member: group^member | $group^member->$group^member#member

        # the inverted permission remain an exclusion permission
        doc^can_act: $doc^viewer - doc^owner

group:
    relations:
        doc^viewer#member: doc
        group^member#member: group
    permissions:
        $doc^viewer#member: doc^viewer#member | $group^member#member->$doc^viewer#member
        $group^member#member: group^member#member | $group^member#member->$group^member#member

        # the inverted permission becomes a union
        doc^can_act#member: $doc^viewer#member
```
