### PR TITLE
Fix GetGraph bug

### DIFF
--- a/graph/check_test.yaml
+++ b/graph/check_test.yaml
@@ -63,10 +63,12 @@ types:
       can_invite: parent->can_read - viewer
 
       # viewer can be user or group but owner can only be user
+      union_type_subset: viewer | owner
+      union_type_subset_arrow: viewer | parent->owner
       negation_type_subset: viewer - owner
-
-      # viewer can be user or group but owner can only be user
+      negation_type_subset_arrow: viewer - parent->owner
       intersection_type_subset: viewer & owner
+      intersection_type_subset_arrow: viewer & parent->owner
 
   cycle:
     relations:

--- a/graph/objects.go
+++ b/graph/objects.go
@@ -7,6 +7,7 @@ import (
 	dsc "github.com/aserto-dev/go-directory/aserto/directory/common/v3"
 	dsr "github.com/aserto-dev/go-directory/aserto/directory/reader/v3"
 	"github.com/aserto-dev/go-directory/pkg/derr"
+	"github.com/rs/zerolog/log"
 	"github.com/samber/lo"
 )
 
@@ -25,8 +26,9 @@ func NewObjectSearch(m *model.Model, req *dsr.GetGraphRequest, reader RelationRe
 	// validate the model but skip name validation. To avoid name collisions, the inverted model
 	// uses mangled names that are not valid identifiers.
 	if err := im.Validate(model.SkipNameValidation, model.AllowPermissionInArrowBase); err != nil {
+		log.Err(err).Interface("req", req).Msg("inverted model is invalid")
 		// TODO: we should persist the inverted model instead of computing it on the fly.
-		return nil, derr.ErrUnknown.Msg("internal error: unable to search for objects.")
+		return nil, derr.ErrUnknown.Msg("internal error: unable to search objects.")
 	}
 
 	iParams := invertGetGraphRequest(im, req)

--- a/model/inverse.go
+++ b/model/inverse.go
@@ -194,7 +194,10 @@ func (ti *termInverter) invertArrow() {
 	itip := ti.inv.irelSub(ti.objName, ti.term.Base)
 	baseRel := ti.obj.Relations[ti.term.Base]
 
-	typeRefs := set.NewSet(ti.perm.Types()...)
+	typeRefs := set.NewSet(ti.term.Types()...)
+	if typeRefs.IsEmpty() {
+		typeRefs.Append(ti.perm.Types()...)
+	}
 	typeRefs.Intersect(ti.typeSet).Each(func(rr RelationRef) bool {
 		iName := InverseRelation(ti.objName, ti.permName, rr.Relation)
 		iPerm := permissionOrNew(ti.inv.im.Objects[rr.Object], iName, ti.kind)


### PR DESCRIPTION
This fixes a model-inversion bug. 

Given:
```yaml
folder:
  relations:
    parent: folder
    owner: user
  permissions:
    is_owner: owner | parent->is_owner

doc:
  relations:
    parent: folder
    viewer: user | user:* | group#member
  permissions:
    can_view: viewer | parent->owner
```

The `can_view` premission isn't inverted correctly. A `group#member` can have the `can_view` permission, but only through the first term (`viewer`) because `parent->is_owner` can only be a `user`.
The problem is that the inversion logic attempts to create the inversion of `parent->owner` on `group`
(i.e. `group#doc^can_view#member: doc_viewer#member | doc_owner#doc_parent`) But `group` has no `doc_owner` relation because `group#member` isn't assignable to`folder#owner`.