### PR TITLE
Fix model inversion bug

### DIFF
--- a/graph/check_test.yaml
+++ b/graph/check_test.yaml
@@ -76,3 +76,14 @@ types:
       owner: user
     permissions:
       can_delete: owner & parent->can_delete
+
+  # A group#member can be a resource#editor in two ways:
+  # 1. Excplicit assignement (resource#editor@group#member)
+  # 2. Indirectly via editors#member@group#member
+  resource:
+    relations:
+      editor: user | group#member | editors#member
+  editors:
+    relations:
+      member: user | group#member
+

--- a/model/validate.go
+++ b/model/validate.go
@@ -302,7 +302,12 @@ func (v *validator) resolvePermissions() error {
 }
 
 func (v *validator) resolvePermission(ref *RelationRef, seen relSet) (objSet, relSet) {
-	p := v.Objects[ref.Object].Permissions[ref.Relation]
+	p, ok := v.Objects[ref.Object].Permissions[ref.Relation]
+	if !ok {
+		// No such permission. Most likely a bug in the model inversion logic.
+		// Return empty sets which result in a validation error.
+		return set.NewSet[ObjectName](), set.NewSet[RelationRef]()
+	}
 
 	if len(p.SubjectTypes) > 0 {
 		// already resolved


### PR DESCRIPTION
With the standard `user` and `group` types, the following definition causes an error when inverting the model:

```yaml
resource:
  relations:
    editor: user | group#member | editors#member

editors:
  relations:
    member: user | group#member
```

This commit fixes the problem and adds tests.