### PR TITLE
Add missing check in relation inversion logic

### DIFF
--- a/graph/check_test.yaml
+++ b/graph/check_test.yaml
@@ -54,6 +54,7 @@ types:
       owner: user
       parent: folder
       viewer: user | user:* | group#member
+      auditor: user#manager
     permissions:
       can_view: viewer
       can_change_owner: owner | parent->is_owner
@@ -86,4 +87,3 @@ types:
   editors:
     relations:
       member: user | group#member
-

--- a/graph/objects.go
+++ b/graph/objects.go
@@ -93,7 +93,7 @@ func (s *ObjectSearch) Search() (*dsr.GetGraphResponse, error) {
 }
 
 func invertGetGraphRequest(im *model.Model, req *dsr.GetGraphRequest) *relation {
-	rel := model.InverseRelation(model.ObjectName(req.ObjectType), model.RelationName(req.Relation))
+	rel := model.InverseRelation(model.ObjectName(req.ObjectType), model.RelationName(req.Relation), model.RelationName(req.SubjectRelation))
 	relPerm := model.PermForRel(rel)
 	if im.Objects[model.ObjectName(req.SubjectType)].HasPermission(relPerm) {
 		rel = relPerm

--- a/graph/objects_test.go
+++ b/graph/objects_test.go
@@ -91,6 +91,8 @@ var searchObjectsTests = []searchTest{
 	{"group:?#member@user:user3", []object{{"group", "d1_subviewers"}, {"group", "d1_viewers"}}},
 	{"group:?#member@user:yin_user", []object{{"group", "yin"}, {"group", "yang"}}},
 	{"doc:?#viewer@group:d1_subviewers#member", []object{{"doc", "doc1"}}},
+	{"doc:?#auditor@user:boss", []object{{"doc", "doc1"}}},
+	{"doc:?#auditor@user:employee#manager", []object{{"doc", "doc1"}}},
 
 	// wildcard
 	{"doc:?#viewer@user:user1", []object{{"doc", "doc1"}, {"doc", "doc2"}}},
@@ -192,6 +194,8 @@ func relations() RelationsReader {
 		"doc:doc2#viewer@user:*",
 		"doc:doc2#viewer@user:user2",
 		"doc:doc3#parent@folder:folder2",
+		"user:employee#manager@user:boss",
+		"doc:doc1#auditor@user:employee#manager",
 
 		"group:d1_viewers#member@group:d1_subviewers#member",
 		"group:d1_subviewers#member@user:user3",

--- a/model/inverse.go
+++ b/model/inverse.go
@@ -90,7 +90,9 @@ func (i *inverter) invertRelation(on ObjectName, rn RelationName, r *Relation) {
 				p := permissionOrNew(i.im.Objects[subj.Object], ipn, permissionKindUnion)
 				i.addSubstitution(ipr, ipn)
 				if _, ok := unionObjs[subj.Object]; ok {
-					p.AddTerm(&PermissionTerm{RelOrPerm: InverseRelation(on, rn, subj.Relation)})
+					if i.im.Objects[subj.Object].HasRelOrPerm(ipr) {
+						p.AddTerm(&PermissionTerm{RelOrPerm: ipr})
+					}
 				}
 				p.AddTerm(&PermissionTerm{Base: InverseRelation(rr.Object, rr.Relation, subj.Relation), RelOrPerm: irn})
 			}


### PR DESCRIPTION
It was adding terms that refer to non-existent realtions.

The following manifest causes an error when calling GetGraph to search for objects that a given subject has access to.

```yaml
user:
  relations:
    manager: user

resource:
  relations:
    viewer: user#manager
```