### PR TITLE
Fix inversion of relations that can only accept wildcards

### DIFF
--- a/graph/check.go
+++ b/graph/check.go
@@ -126,7 +126,7 @@ func (c *Checker) checkRelation(params *relation) (checkStatus, error) {
 		case step.IsDirect() && (params.tail == "" || params.tail == params.rel):
 			req.SubjectId = params.sid.String()
 		case step.IsWildcard():
-			req.SubjectId = "*"
+			req.SubjectId = model.WildcardSymbol
 		case step.IsSubject():
 			req.SubjectRelation = step.Relation.String()
 		}

--- a/graph/computed_set.yaml
+++ b/graph/computed_set.yaml
@@ -24,8 +24,9 @@ types:
   resource:
     relations:
       viewer: user | machine | identity | group#member
+      public_viewer: user:* | identity:*
     permissions:
-      can_view: viewer | viewer->identifier
+      can_view: viewer | viewer->identifier | public_viewer
 
   component:
     relations:

--- a/graph/computed_set_test.go
+++ b/graph/computed_set_test.go
@@ -24,8 +24,22 @@ func TestComputedSet(t *testing.T) {
 		check    string
 		expected bool
 	}{
-		{"resource:album#can_view@identity:zappa", true},
 		{"resource:album#can_view@user:frank", true},
+		{"resource:album#can_view@user:seymour", false},
+		{"resource:album#can_view@identity:zappa", true},
+		{"resource:album#can_view@identity:duncan", false},
+		{"resource:poster#can_view@user:frank", true},
+		{"resource:poster#can_view@user:seymour", true},
+		{"resource:poster#can_view@identity:zappa", false},
+		{"resource:poster#can_view@identity:duncan", false},
+		{"resource:t_shirt#can_view@user:frank", false},
+		{"resource:t_shirt#can_view@user:seymour", false},
+		{"resource:t_shirt#can_view@identity:zappa", true},
+		{"resource:t_shirt#can_view@identity:duncan", true},
+		{"resource:concert#can_view@user:frank", true},
+		{"resource:concert#can_view@user:seymour", true},
+		{"resource:concert#can_view@identity:zappa", true},
+		{"resource:concert#can_view@identity:duncan", true},
 
 		{"component:guitar#can_repair@identity:zappa", true},
 		{"component:guitar#can_repair@user:frank", true},
@@ -68,9 +82,15 @@ func TestComputedSetSearchSubjects(t *testing.T) {
 
 	tests := []searchTest{
 		{"user:frank#identifier@identity:?", []object{{"identity", "zappa"}}},
-		{"resource:album#can_view@user:?", []object{{"user", "frank"}}},
+		{"resource:album#can_view@user:?", []object{{"user", "frank"}, {"user", "unidentified"}}},
 		{"resource:album#can_view@identity:?", []object{{"identity", "zappa"}}},
-		{"component:guitar#can_repair@user:?", []object{{"user", "seymour"}, {"user", "frank"}}},
+		{"resource:poster#can_view@user:?", []object{{"user", "*"}}},
+		{"resource:poster#can_view@identity:?", []object{}},
+		{"resource:t_shirt#can_view@user:?", []object{}},
+		{"resource:t_shirt#can_view@identity:?", []object{{"identity", "*"}}},
+		{"resource:concert#can_view@user:?", []object{{"user", "*"}}},
+		{"resource:concert#can_view@identity:?", []object{{"identity", "*"}}},
+		{"component:guitar#can_repair@user:?", []object{{"user", "seymour"}, {"user", "frank"}, {"user", "unidentified"}}},
 		{"component:guitar#can_repair@identity:?", []object{{"identity", "duncan"}, {"identity", "zappa"}}},
 		{"component:guitar#can_repair@group:?#member", []object{{"group", "guitarists"}}},
 		{"component:pickup#can_repair@identity:?", []object{{"identity", "duncan"}}},
@@ -79,7 +99,7 @@ func TestComputedSetSearchSubjects(t *testing.T) {
 		{"component:magnet#can_repair@user:?", []object{}},
 		{"component:pickup#is_part_maintainer@user:?", []object{{"user", "seymour"}}},
 		{"component:pickup#is_part_maintainer@identity:?", []object{{"identity", "duncan"}}},
-		{"component:guitar#is_part_maintainer@user:?", []object{{"user", "seymour"}, {"user", "frank"}}},
+		{"component:guitar#is_part_maintainer@user:?", []object{{"user", "seymour"}, {"user", "frank"}, {"user", "unidentified"}}},
 		{"component:guitar#is_part_maintainer@identity:?", []object{{"identity", "duncan"}, {"identity", "zappa"}}},
 	}
 
@@ -131,8 +151,12 @@ func TestComputedSetSearchObjects(t *testing.T) {
 
 	tests := []searchTest{
 		{"user:?#identifier@identity:zappa", []object{{"user", "frank"}}},
-		{"resource:?#can_view@user:frank", []object{{"resource", "album"}}},
-		{"resource:?#can_view@identity:zappa", []object{{"resource", "album"}}},
+		{"resource:?#can_view@user:frank", []object{{"resource", "album"}, {"resource", "poster"}, {"resource", "concert"}}},
+		{"resource:?#can_view@identity:zappa", []object{{"resource", "album"}, {"resource", "t_shirt"}, {"resource", "concert"}}},
+		{"resource:?#can_view@user:*", []object{{"resource", "poster"}, {"resource", "concert"}}},
+		{"resource:?#can_view@user:seymour", []object{{"resource", "poster"}, {"resource", "concert"}}},
+		{"resource:?#can_view@identity:*", []object{{"resource", "t_shirt"}, {"resource", "concert"}}},
+		{"resource:?#can_view@identity:duncan", []object{{"resource", "t_shirt"}, {"resource", "concert"}}},
 		{"component:?#can_repair@user:seymour", []object{{"component", "guitar"}, {"component", "pickup"}, {"component", "coil"}}},
 		{"component:?#can_repair@identity:duncan", []object{{"component", "guitar"}, {"component", "pickup"}, {"component", "coil"}}},
 		{"component:?#can_repair@user:frank", []object{{"component", "guitar"}, {"component", "string"}}},
@@ -171,8 +195,13 @@ func TestComputedSetSearchObjects(t *testing.T) {
 var csRels = NewRelationsReader(
 	"user:frank#identifier@identity:zappa",
 	"group:guitarists#member@user:frank",
+	"group:guitarists#member@user:unidentified",
 	"group:musicians#member@group:guitarists#member",
 	"resource:album#viewer@group:musicians#member",
+	"resource:poster#public_viewer@user:*",
+	"resource:t_shirt#public_viewer@identity:*",
+	"resource:concert#public_viewer@user:*",
+	"resource:concert#public_viewer@identity:*",
 
 	"user:seymour#identifier@identity:duncan",
 	"component:coil#maintainer@user:seymour",

--- a/graph/objects.go
+++ b/graph/objects.go
@@ -123,7 +123,7 @@ func invertGetGraphRequest(im *model.Model, req *dsr.GetGraphRequest) *relation 
 
 func wildcardParams(params *relation) *relation {
 	wildcard := *params
-	wildcard.oid = "*"
+	wildcard.oid = model.WildcardSymbol
 	return &wildcard
 }
 
@@ -156,7 +156,7 @@ func uninvertRelation(m *model.Model, r *relation) *relation {
 	relSplit := strings.SplitN(objSplit[1], model.SubjectRelationSeparator, 2)
 	rel := relSplit[0]
 	srel := ""
-	if len(relSplit) > 1 {
+	if len(relSplit) > 1 && relSplit[1] != model.WildcardSymbol {
 		srel = relSplit[1]
 	}
 

--- a/graph/objects_test.go
+++ b/graph/objects_test.go
@@ -103,8 +103,9 @@ var searchObjectsTests = []searchTest{
 	{"doc:?#viewer@user:f1_owner", []object{{"doc", "doc1"}, {"doc", "doc2"}}},
 	{"doc:?#viewer@user:user2", []object{{"doc", "doc1"}, {"doc", "doc2"}}},
 	{"doc:?#viewer@user:*", []object{{"doc", "doc2"}}},
+	{"doc:?#viewer@user:some_user", []object{{"doc", "doc2"}}},
 
-	// // Permissions
+	// Permissions
 	{"folder:?#is_owner@user:f1_owner", []object{{"folder", "folder1"}, {"folder", "folder2"}}},
 	{"folder:?#can_create_file@user:f1_owner", []object{{"folder", "folder1"}, {"folder", "folder2"}}},
 	{"folder:?#can_read@user:f1_owner", []object{{"folder", "folder1"}, {"folder", "folder2"}}},
@@ -180,6 +181,7 @@ var searchObjectsTests = []searchTest{
 	{"doc:?#can_read@user:user3", []object{{"doc", "doc1"}, {"doc", "doc2"}}},
 	{"doc:?#can_share@user:user3", []object{}},
 	{"doc:?#can_invite@user:user3", []object{}},
+	{"doc:?#can_view@user:some_user", []object{{"doc", "doc2"}}},
 }
 
 func relations() RelationsReader {

--- a/graph/subjects.go
+++ b/graph/subjects.go
@@ -118,7 +118,7 @@ func (s *SubjectSearch) searchRelation(params *relation) (searchResults, error) 
 func (s *SubjectSearch) findNeighbor(step *model.RelationRef, params *relation) (searchResults, error) {
 	sid := params.sid.String()
 	if step.IsWildcard() {
-		sid = "*"
+		sid = model.WildcardSymbol
 	}
 
 	req := &dsc.RelationIdentifier{

--- a/model/model.go
+++ b/model/model.go
@@ -13,7 +13,12 @@ import (
 	"github.com/samber/lo"
 )
 
-const ModelVersion int = 5
+const (
+	ModelVersion int = 5
+
+	ArrowSymbol    = "->"
+	WildcardSymbol = "*"
+)
 
 type Model struct {
 	Version  int                    `json:"version"`
@@ -45,7 +50,7 @@ func (id ObjectID) String() string {
 }
 
 func (id ObjectID) IsWildcard() bool {
-	return id == "*"
+	return id == WildcardSymbol
 }
 
 type relation struct {
@@ -149,7 +154,7 @@ func (m *Model) ValidateRelation(on ObjectName, oid ObjectID, rn RelationName, s
 
 	if rel.sid.IsWildcard() {
 		// Wildcard assignment.
-		assignment.Relation = "*"
+		assignment.Relation = WildcardSymbol
 
 		if rel.srn != "" {
 			return derr.ErrInvalidRelation.Msgf("[%s] wildcard assignment cannot include subject relation", rel)

--- a/model/types.go
+++ b/model/types.go
@@ -148,7 +148,7 @@ func (rr *RelationRef) Assignment() RelationAssignment {
 	}
 
 	switch {
-	case rr.Relation == "*":
+	case rr.Relation == WildcardSymbol:
 		return RelationAssignmentWildcard
 	case rr.Relation != "":
 		return RelationAssignmentSubject
@@ -248,7 +248,7 @@ func (pr *PermissionTerm) String() string {
 	}
 	s := string(pr.RelOrPerm)
 	if pr.Base != "" {
-		s = string(pr.Base) + "->" + s
+		s = string(pr.Base) + ArrowSymbol + s
 	}
 	return s
 }

--- a/model/validate.go
+++ b/model/validate.go
@@ -233,15 +233,15 @@ func (v *validator) validatePermission(on ObjectName, pn RelationName, p *Permis
 			for _, ref := range r.Union {
 				if ref.IsWildcard() {
 					errs = multierror.Append(errs, derr.ErrInvalidPermission.Msgf(
-						"wildcard relation '%s:%s' not allowed in the base of an arrow operator '%s->%s' in permission '%s:%s'",
-						on, term.Base, term.Base, term.RelOrPerm, on, pn,
+						"wildcard relation '%s:%s' not allowed in the base of an arrow operator '%s%s%s' in permission '%s:%s'",
+						on, term.Base, term.Base, ArrowSymbol, term.RelOrPerm, on, pn,
 					))
 				}
 			}
 
 			for _, st := range r.SubjectTypes {
 				if !v.Objects[st].HasRelOrPerm(term.RelOrPerm) {
-					arrow := fmt.Sprintf("%s->%s", term.Base, term.RelOrPerm)
+					arrow := fmt.Sprintf("%s%s%s", term.Base, ArrowSymbol, term.RelOrPerm)
 					errs = multierror.Append(errs, derr.ErrInvalidPermission.Msgf(
 						"permission '%s:%s' references '%s', which can resolve to undefined relation or permission '%s:%s' ",
 						on, pn, arrow, st, term.RelOrPerm,

--- a/parser/relation_visitor.go
+++ b/parser/relation_visitor.go
@@ -36,7 +36,7 @@ func (v *RelationVisitor) VisitDirectRel(c *DirectRelContext) interface{} {
 func (v *RelationVisitor) VisitWildcardRel(c *WildcardRelContext) interface{} {
 	return &model.RelationRef{
 		Object:   model.ObjectName(c.Wildcard().ID().GetText()),
-		Relation: "*",
+		Relation: model.WildcardSymbol,
 	}
 }
 

--- a/v3/manifest.go
+++ b/v3/manifest.go
@@ -9,10 +9,6 @@ import (
 
 const SupportedSchemaVersion int = 3
 
-const (
-	ArrowIdentifier string = "->"
-)
-
 type Manifest struct {
 	ModelInfo   *ModelInfo                     `yaml:"model"`
 	ObjectTypes map[ObjectTypeName]*ObjectType `yaml:"types"`


### PR DESCRIPTION
A bug in the inversion logic was causing it to produce an invalid model when a permission is defined using a relation that can only accept wildcard assignments.

For example, searching for objects with the manifest below would result in an error:
```yaml
model:
  version: 3

types:
  user: {}

  resource:
    relations:
      public: user:*

    permissions:
      can_view: public
```

This PR fixes the bug.